### PR TITLE
Rewrote timeObj to use the standard method for rollover.

### DIFF
--- a/timeObj.cpp
+++ b/timeObj.cpp
@@ -25,67 +25,32 @@ void timeObj::setTime(float inMs,bool startNow) {
 
 void timeObj::start(void) {
 
-    if (waitTime==0) {
-        config = zero;
-    } else {
-        startTime = micros();
-        endTime = startTime + waitTime;
-        if (endTime < startTime) {
-            config = crossing;
-        } else {
-            config = normal;
-        }
-    }
+	startTime = micros();
+	endTime = startTime + waitTime;
 }
 
 
 void timeObj::stepTime(void) {
 
-    if (config!=zero) {
-        startTime = endTime;
-        endTime = startTime + waitTime;
-        if (endTime < startTime) {
-            config = crossing;
-        } else {
-            config = normal;
-        }
-    }
+	if (waitTime>0) {
+		startTime = endTime;
+		endTime = startTime + waitTime;
+	}
 }
 
 
-bool timeObj::ding(void) {
-  
-  unsigned long now;
-    
-    now = micros();
-    switch (config) {
-        case zero : return true;
-        case crossing :
-            if (now >= startTime || now < endTime)
-                return false;
-            else
-                return true;
-        break;
-        case normal :
-            if (now >= startTime && now < endTime)
-                return false;
-            else
-                return true;
-        break;
-    }
-    return true;    // To shut up compiler and shut down a broken timer.
-}
+bool timeObj::ding(void) { return micros() - startTime > waitTime; }
 
 
 unsigned long timeObj::getTime(void) { return waitTime; }
 
 
-// Fuel gauge. What fraction of time is left.
+// Fuel gauge. What fraction of time is left. Will this work with overruns? Dunno'. Deal
+// with that when we run into it.
 float timeObj::getFraction(void) {
 	
 	unsigned long remaining;
 	
-	if (config==zero) return 0;
 	if (ding()) return 0;
 	remaining = endTime - micros();
 	return((remaining/1000.0)/(waitTime/1000.0));

--- a/timeObj.h
+++ b/timeObj.h
@@ -6,6 +6,9 @@
 // Great for blinking LEDs, updating readings, etc.
 // Not fast & accurate enough for RC Servos.
 // *** Takes care of roll over issues ***
+//
+// NOTE: Once the timer expires, every call to ding() will return true until its been
+// restarted.
 
 enum timeType { zero, crossing, normal };
 
@@ -26,7 +29,6 @@ protected:
   				unsigned long	waitTime;
   				unsigned long	startTime;
   				unsigned long	endTime;
-  				timeType			config;
 };
 
 #endif


### PR DESCRIPTION
I'd written a way to handle rollover that included states and such forth. Turns out, doesn't seem like I needed all that. Just subtract  start time from current time and compare that to wait time, nnd you're done. Well, we'll see if that works.